### PR TITLE
Add python package python-fasteners

### DIFF
--- a/install-duplicity
+++ b/install-duplicity
@@ -19,7 +19,7 @@
 yum -y install wget gcc rsync \
                python-devel python-pip librsync-devel python-lockfile \
                python-paramiko python-crypto python-boto
-pip install PyDrive python-swiftclient python-keystoneclient
+pip install PyDrive python-swiftclient python-keystoneclient python-fasteners
 
 # Prepare dir
 cd


### PR DESCRIPTION
In fresh CentOS 7 python-fasteners required to run duplicity